### PR TITLE
feature: import tabs with renamed titles

### DIFF
--- a/main.py
+++ b/main.py
@@ -103,7 +103,7 @@ def convert_to_bookmarks(spaces: dict, items: list) -> dict:
                 if "data" in item and "tab" in item["data"]:
                     children.append(
                         {
-                            "title": item["data"]["tab"].get("savedTitle", ""),
+                            "title": item.get("title", None) or item["data"]["tab"].get("savedTitle", ""),
                             "type": "bookmark",
                             "url": item["data"]["tab"].get("savedURL", ""),
                         }


### PR DESCRIPTION
Hello! Thanks for this useful project!

I used the project to export my pinned tabs of Arc, but noticed that it would import tabs with the original title, instead of the titles I gave them in Arc. As I was a heavy user of renaming tabs, it was frustrating to me.

I made this changes local and it worked 😄 Instead of going on `savedTitle`, I check first if exists a title. I saw that when you rename a tab, `title` would be filled. Otherwise, title will be `null`.

If you find it interesting, here is the change I made.

Thank you again!