### PR TITLE
Fix finding the target global container

### DIFF
--- a/main.py
+++ b/main.py
@@ -61,7 +61,10 @@ def read_json() -> dict:
 
 def convert_json_to_html(json_data: dict) -> str:
     containers: list = json_data["sidebar"]["containers"]
-    target: int = next(i + 1 for i, c in enumerate(containers) if "global" in c)
+    try:
+        target: int = next(i + 1 for i, c in enumerate(containers) if "global" in c)
+    except StopIteration:
+        raise ValueError("No container with 'global' found in the sidebar data")
 
     spaces: dict = get_spaces(json_data["sidebar"]["containers"][target]["spaces"])
     items: list = json_data["sidebar"]["containers"][target]["items"]

--- a/main.py
+++ b/main.py
@@ -61,7 +61,7 @@ def read_json() -> dict:
 
 def convert_json_to_html(json_data: dict) -> str:
     containers: list = json_data["sidebar"]["containers"]
-    target: int = sum([1 for i in containers if "global" in i])
+    target: int = next(i + 1 for i, c in enumerate(containers) if "global" in c)
 
     spaces: dict = get_spaces(json_data["sidebar"]["containers"][target]["spaces"])
     items: list = json_data["sidebar"]["containers"][target]["items"]


### PR DESCRIPTION
The code submitted in PR #5 will always give an index of 1 which is wrong and gave no bookmarks when I ran the script. What we actually want is the index after the container containing `global`. This PR fixes that bug but still does it in a pretty one-liner.