### PR TITLE
Using different heading levels

### DIFF
--- a/main.py
+++ b/main.py
@@ -276,7 +276,9 @@ def convert_bookmarks_to_html(bookmarks: dict) -> str:
         indent: str = "\t" * level
         for item in d:
             if item["type"] == "folder":
-                html_str += f'\n{indent}<DT><H3>{item["title"]}</H3>'
+                # We want to start at H2, because H1 is the page title
+                tag = "H" + str(level + 1)
+                html_str += f'\n{indent}<DT><{tag}>{item["title"]}</{tag}>'
                 html_str += f"\n{indent}<DL><p>"
                 html_str = traverse_dict(item["children"], html_str, level + 1)
                 html_str += f"\n{indent}</DL><p>"

--- a/main.py
+++ b/main.py
@@ -276,8 +276,8 @@ def convert_bookmarks_to_html(bookmarks: dict) -> str:
         indent: str = "\t" * level
         for item in d:
             if item["type"] == "folder":
-                # We want to start at H2, because H1 is the page title
-                tag = "H" + str(level + 1)
+                # We want to start at H2, because H1 is the page title. 
+                tag = "H" + str(level + 1) if level <= 5 else "H6"
                 html_str += f'\n{indent}<DT><{tag}>{item["title"]}</{tag}>'
                 html_str += f"\n{indent}<DL><p>"
                 html_str = traverse_dict(item["children"], html_str, level + 1)


### PR DESCRIPTION
Currently, the script produces `<H3>` for all folder titles. It is difficult to understand the structure when simply opening the file in a browser instead of importing the bookmarks.

I have changed a few lines to make the headings change based on nesting level (starting with `<H2>` and ending with `<H6>`).

I have tested importing the modified output file into Firefox and no problems have occurred.