### PR TITLE
Adding Favorites to Exported Bookmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+StorableSidebar.json
+bookmarks.html

--- a/main.py
+++ b/main.py
@@ -171,6 +171,43 @@ def read_json() -> dict:
     return data
 
 
+
+def get_favorites(items: list):
+    '''
+    X1) Iterate through the items and find a match where the container type =topapps and the topApps=_0 and the _0 = default
+    X2) Get all of the children ids from the object 
+    3) Relate those children ids to their data 
+    4) Compose the data the same format that the convert_bookmarks_to_html expects
+    5) Connect
+    '''
+    children_ids=None
+    for item in items:
+        if not isinstance(item, dict):
+            continue 
+        container_type = (
+            item.get("value",{})
+            .get("data", {})
+            .get("itemContainer", {})
+            .get("containerType",{})
+        )
+        if (
+            "topApps" in container_type
+            and "_0" in container_type.get("topApps", {})
+            and "default" in container_type["topApps"]["_0"]
+            and item.get("parentID") is None
+        ):
+            children_ids:list = item.get("value").get("childrenIds")
+            logging.debug(f"Found favorites: {children_ids}")
+            break
+    if not children_ids:
+        return None
+
+    
+                
+
+            
+
+
 def convert_json_to_html(json_data: dict) -> str:
     containers: list = json_data["sidebar"]["containers"]
     try:
@@ -181,7 +218,9 @@ def convert_json_to_html(json_data: dict) -> str:
     spaces: dict = get_spaces(json_data["sidebar"]["containers"][target]["spaces"])
     items: list = json_data["sidebar"]["containers"][target]["items"]
 
+    favorites: dict = get_favorites(json_data["sidebarSyncState"]["items"])
     bookmarks: dict = convert_to_bookmarks(spaces, items)
+    # we will append the new bookmarks right here.
     html_content: str = convert_bookmarks_to_html(bookmarks)
 
     return html_content

--- a/main.py
+++ b/main.py
@@ -281,8 +281,7 @@ def recurse_into_children(parent_id:str, items:dict) -> list:
                 url = item["data"]["tab"].get("savedURL", "")
                 bookmark = build_bookmark_entry(title, url)
                 children.append(bookmark)
-            
-               #bookmarks_count += 1
+        
             elif "title" in item:    
                 child_folder = build_folder_entry(title=item["title"], children=recurse_into_children(item_id, items))
                 children.append(child_folder)
@@ -292,14 +291,11 @@ def convert_to_bookmarks(spaces: dict, items: list) -> dict:
     logging.info("Converting to bookmarks...")
 
     bookmarks: dict = {"bookmarks": []}
-    #bookmarks_count: int = 0
     item_dict: dict = {item["id"]: item for item in items if isinstance(item, dict)}
 
     for space_id, space_name in spaces["pinned"].items():
         space_folder = build_folder_entry(title=space_name, children=recurse_into_children(space_id, item_dict))
         bookmarks["bookmarks"].append(space_folder)
-
-    #logging.debug(f"Found {bookmarks_count} bookmarks.")
 
     return bookmarks
 


### PR DESCRIPTION
Fixes #32: Export Arc favorites to bookmarks

As reported in issue #32 by @webserviceXXL, Arc's favorites (pinned items that exist across all spaces) were not being exported. This PR adds support for exporting them into a "Favorites" folder at the top of the bookmarks hierarchy.

Additional changes:
- Refactored bookmark/folder creation into reusable `build_bookmark_entry()` and `build_folder_entry()` functions to reduce code duplication